### PR TITLE
Add doc examples for flex-box + Space-between

### DIFF
--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -36,6 +36,8 @@ const dotSize = computed(() => props.size + 'px')
   --tw-indigo-bg: #818cf81a;
   --tw-blue-fg: #3b82f680;
   --tw-blue-bg: #60a5fa1a;
+  --tw-cyan-fg: #06b6d480;
+  --tw-cyan-bg: #22d3ee1a;
   --tw-fuchsia-fg: #d946ef80;
   --tw-fuchsia-bg: #e879f91a;
   --el-color: v-bind(fgColor);

--- a/src/pages/Flex.vue
+++ b/src/pages/Flex.vue
@@ -11,33 +11,118 @@ const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-cente
   <h1>Flex initial</h1>
   <width-controller>
     <container>
-      <box striped class="flex gap-4" fg-color="rgba(2,132,199, 0.5)">
-        <div class="w-14 flex-none bg-sky-300" :class="exampleClasses">01</div>
-        <div class="w-64 flex-initial bg-sky-600" :class="exampleClasses">02</div>
-        <div class="w-32 flex-initial bg-sky-600" :class="exampleClasses">03</div>
+      <box striped class="flex gap-4" fg-color="var(--tw-blue-fg)" bg-color="var(--tw-blue-bg)">
+        <div class="w-14 flex-none bg-blue-800" :class="exampleClasses">01</div>
+        <div class="w-64 flex-initial bg-blue-500" :class="exampleClasses">02</div>
+        <div class="w-32 flex-initial bg-blue-500" :class="exampleClasses">03</div>
       </box>
     </container>
   </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex">
+          <div class="flex-none w-14 h-14">
+            01
+          </div>
+          <div class="flex-initial w-64 ...">
+            02
+          </div>
+          <div class="flex-initial w-32 ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
 
   <h1>Flex 1</h1>
   <width-controller>
     <container>
-      <box striped class="flex gap-4" fg-color="rgba(2,132,199, 0.5)">
-        <div class="w-14 flex-none bg-sky-300" :class="exampleClasses">01</div>
-        <div class="w-64 flex-1 bg-sky-600" :class="exampleClasses">02</div>
-        <div class="w-32 flex-1 bg-sky-600" :class="exampleClasses">03</div>
+      <box striped class="flex gap-4" fg-color="var(--tw-pink-fg)" bg-color="var(--tw-pink-bg)">
+        <div class="w-14 flex-none bg-pink-800" :class="exampleClasses">01</div>
+        <div class="w-64 flex-1 bg-pink-500" :class="exampleClasses">02</div>
+        <div class="w-32 flex-1 bg-pink-500" :class="exampleClasses">03</div>
       </box>
     </container>
   </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex">
+          <div class="flex-none ...">
+            01
+          </div>
+          <div class="flex-1 w-64 ...">
+            02
+          </div>
+          <div class="flex-1 w-32 ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
 
   <h1>Flex auto</h1>
   <width-controller>
     <container>
-      <box striped class="flex gap-4" fg-color="rgba(2,132,199, 0.5)">
-        <div class="w-14 flex-none bg-sky-300" :class="exampleClasses">01</div>
-        <div class="w-64 flex-auto bg-sky-600" :class="exampleClasses">02</div>
-        <div class="w-32 flex-auto bg-sky-600" :class="exampleClasses">03</div>
+      <box striped class="flex gap-4" fg-color="var(--tw-violet-fg)" bg-color="var(--tw-violet-bg)">
+        <div class="w-14 flex-none bg-violet-800" :class="exampleClasses">01</div>
+        <div class="w-64 flex-auto bg-violet-500" :class="exampleClasses">02</div>
+        <div class="w-32 flex-auto bg-violet-500" :class="exampleClasses">03</div>
       </box>
     </container>
   </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex ...">
+          <div class="flex-none ...">
+            01
+          </div>
+          <div class="flex-auto w-64 ...">
+            02
+          </div>
+          <div class="flex-auto w-32 ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+  <h1>Flex None</h1>
+  <width-controller>
+    <container>
+      <box striped class="flex gap-4" fg-color="var(--tw-indigo-fg)" bg-color="var(--tw-indigo-bg)">
+        <div class="w-14 flex-none bg-indigo-800" :class="exampleClasses">01</div>
+        <div class="w-64 flex-none bg-indigo-500" :class="exampleClasses">02</div>
+        <div class="w-32 flex-1 bg-indigo-500" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex ...">
+          <div class="flex-none w-14 h-14...">
+            01
+          </div>
+          <div class="flex-none ...">
+            02
+          </div>
+          <div class="flex-1 ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
 </template>

--- a/src/pages/FlexBasis.vue
+++ b/src/pages/FlexBasis.vue
@@ -1,0 +1,33 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+import WidthController from '../components/WidthController.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Flex basis</h1>
+  <width-controller>
+    <container>
+      <box class="flex gap-4">
+        <div class="basis-1/4 bg-fuchsia-500" :class="exampleClasses">01</div>
+        <div class="basis-1/4 bg-fuchsia-500" :class="exampleClasses">02</div>
+        <div class="basis-1/2 bg-fuchsia-500" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-row">
+          <div class="basis-1/4">01</div>
+          <div class="basis-1/4">02</div>
+          <div class="basis-1/2">03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+</template>

--- a/src/pages/FlexDirection.vue
+++ b/src/pages/FlexDirection.vue
@@ -1,0 +1,103 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+import WidthController from '../components/WidthController.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Row</h1>
+  <width-controller>
+    <container>
+      <box class="flex flex-row gap-4">
+        <div class="bg-fuchsia-500" :class="exampleClasses">01</div>
+        <div class="bg-fuchsia-500" :class="exampleClasses">02</div>
+        <div class="bg-fuchsia-500" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-row ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+  <h1>Row reverse</h1>
+  <width-controller>
+    <container>
+      <box class="flex flex-row-reverse gap-4">
+        <div class="bg-blue-500" :class="exampleClasses">01</div>
+        <div class="bg-blue-500" :class="exampleClasses">02</div>
+        <div class="bg-blue-500" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-row-reversed ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+  <h1>Column</h1>
+  <width-controller>
+    <container>
+      <box class="flex flex-col gap-4">
+        <div class="bg-indigo-500" :class="exampleClasses">01</div>
+        <div class="bg-indigo-500" :class="exampleClasses">02</div>
+        <div class="bg-indigo-500" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-col ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+  <h1>Column reverse</h1>
+  <width-controller>
+    <container>
+      <box class="flex flex-col-reverse gap-4">
+        <div class="bg-violet-500" :class="exampleClasses">01</div>
+        <div class="bg-violet-500" :class="exampleClasses">02</div>
+        <div class="bg-violet-500" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-col-reversed ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/FlexGrow.vue
+++ b/src/pages/FlexGrow.vue
@@ -1,0 +1,70 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+import WidthController from '../components/WidthController.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Grow</h1>
+  <width-controller>
+    <container>
+      <box striped class="flex gap-4" fg-color="var(--tw-blue-fg)" bg-color="var(--tw-blue-bg)">
+        <div class="w-14 h-14 flex-none bg-indigo-800" :class="exampleClasses">01</div>
+        <div class="grow h-14 bg-indigo-500" :class="exampleClasses">02</div>
+        <div class="w-14 h-14 flex-none bg-indigo-800" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex">
+          <div class="flex-none ...">
+            01
+          </div>
+          <div class="grow ...">
+            02
+          </div>
+          <div class="flex-none ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+
+  <h1>Do not grow</h1>
+  <width-controller>
+    <container>
+      <box striped class="flex gap-4" fg-color="var(--tw-pink-fg)" bg-color="var(--tw-pink-bg)">
+        <div class="h-14 grow bg-pink-800" :class="exampleClasses">01</div>
+        <div class="h-14 grow-0 flex-1 bg-pink-500" :class="exampleClasses">02</div>
+        <div class="h-14 grow bg-pink-800" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex">
+          <div class="grow ...">
+            01
+          </div>
+          <div class="grow-0 ...">
+            02
+          </div>
+          <div class="grow ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/FlexShrink.vue
+++ b/src/pages/FlexShrink.vue
@@ -1,0 +1,70 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+import WidthController from '../components/WidthController.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Shrink</h1>
+  <width-controller>
+    <container>
+      <box striped class="flex gap-4" fg-color="var(--tw-blue-fg)" bg-color="var(--tw-blue-bg)">
+        <div class="w-14 h-14 flex-none bg-indigo-800" :class="exampleClasses">01</div>
+        <div class="w-64 h-14 shrink bg-indigo-500" :class="exampleClasses">02</div>
+        <div class="w-14 h-14 flex-none bg-indigo-800" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex">
+          <div class="flex-none ...">
+            01
+          </div>
+          <div class="shrink ...">
+            02
+          </div>
+          <div class="flex-none ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+
+  <h1>Do not shrink</h1>
+  <width-controller>
+    <container>
+      <box striped class="flex gap-4" fg-color="var(--tw-pink-fg)" bg-color="var(--tw-pink-bg)">
+        <div class="h-14 flex-1 bg-pink-800" :class="exampleClasses">01</div>
+        <div class="h-14 w-32 shrink-0 bg-pink-500" :class="exampleClasses">02</div>
+        <div class="h-14 flex-1 bg-pink-800" :class="exampleClasses">03</div>
+      </box>
+    </container>
+  </width-controller>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex">
+          <div class="flex-1 ...">
+            01
+          </div>
+          <div class="shrink-0 w-32 ...">
+            02
+          </div>
+          <div class="flex-1 ...">
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/FlexWrap.vue
+++ b/src/pages/FlexWrap.vue
@@ -1,0 +1,74 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+import WidthController from '../components/WidthController.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Do not wrap</h1>
+  <container class="overflow-auto">
+    <box class="flex flex-nowrap gap-4">
+      <div class="w-2/5 flex-none bg-sky-500" :class="exampleClasses">01</div>
+      <div class="w-2/5 flex-none bg-sky-500" :class="exampleClasses">02</div>
+      <div class="w-2/5 flex-none bg-sky-500" :class="exampleClasses">03</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-nowrap ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+  <h1>Wrap normally</h1>
+  <container>
+    <box class="flex flex-wrap gap-4">
+      <div class="w-2/5 flex-none bg-indigo-500" :class="exampleClasses">01</div>
+      <div class="w-2/5 flex-none bg-indigo-500" :class="exampleClasses">02</div>
+      <div class="w-2/5 flex-none bg-indigo-500" :class="exampleClasses">03</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-row-reversed ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+  <h1>Wrap reversed</h1>
+  <container>
+    <box class="flex flex-wrap-reverse gap-4">
+      <div class="w-2/5 flex-none bg-fuchsia-500" :class="exampleClasses">01</div>
+      <div class="w-2/5 flex-none bg-fuchsia-500" :class="exampleClasses">02</div>
+      <div class="w-2/5 flex-none bg-fuchsia-500" :class="exampleClasses">03</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-row-reversed ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/Spacing.vue
+++ b/src/pages/Spacing.vue
@@ -1,22 +1,26 @@
 <script setup>
-// Note there's a way we can just import these globally so we don't have to do it in every page
-import Box from '../components/Box.vue'
-import Container from '../components/Container.vue'
-import WidthController from '../components/WidthController.vue'
+  // Note there's a way we can just import these globally so we don't have to do it in every page
+  import Box from '../components/Box.vue'
+  import Container from '../components/Container.vue'
+  import WidthController from '../components/WidthController.vue'
 
-const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+  const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
 </script>
 <style>
-/* Support, yay or nay? They are nice */
-/* Same effect as -m-4 on parent and m-4 on children */ 
-.space-x-4 > * + * {
-  margin-left: 1rem; 
-}
 
+  /* Support, yay or nay? They are nice */
+  /* Same effect as -m-4 on parent and m-4 on children */ 
+  .space-x-4 > * + * {
+    margin-left: 1rem; 
+  }
+  .space-y-4 > * + * {
+    margin-top: 1rem; 
+  }
+  .space-x-reverse > * + * {	
+    --w-space-x-reverse: 1;
+  }
 </style>
 <template>
-
-  <!-- **** -->
 
   <h1>Basic usage</h1>
   <container>
@@ -274,4 +278,55 @@ const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-cente
       -->
     </syntax-highlighter>    
   </container>
+
+  <h1>Add vertical space between children</h1>
+  <container>
+    <div class="relative rounded-xl overflow-auto p-8">
+      <div class="flex flex-col justify-center text-center w-full font-mono text-white text-sm font-bold leading-6">
+        <box striped class="flex flex-col space-y-4 bg-stripes-indigo rounded-lg" fg-color="var(--tw-indigo-fg)" bg-color="var(--tw-indigo-bg)">
+          <div class="p-4 flex items-center justify-center shadow-lg rounded-lg bg-indigo-500">01</div>
+          <div class="p-4 flex items-center justify-center shadow-lg rounded-lg bg-indigo-500">02</div>
+          <div class="p-4 flex items-center justify-center shadow-lg rounded-lg bg-indigo-500">03</div>
+        </box>
+      </div>
+    </div>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-col space-y-4 ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+  <h1>Reversing children order</h1>
+  <container>
+    <div class="relative rounded-xl overflow-auto p-8">
+      <div class="flex justify-end font-mono text-white text-sm font-bold leading-6">
+        <box striped class="flex flex-row-reverse space-x-4 space-x-reverse rounded-lg" fg-color="var(--tw-cyan-fg)" bg-color="var(--tw-cyan-bg)">
+          <div class="w-14 h-14 flex items-center justify-center shadow-lg rounded-lg bg-cyan-500">01</div>
+          <div class="w-14 h-14 flex items-center justify-center shadow-lg rounded-lg bg-cyan-500">02</div>
+          <div class="w-14 h-14 flex items-center justify-center shadow-lg rounded-lg bg-cyan-500">03</div>
+        </box>
+      </div>
+    </div>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex flex-row-reverse space-x-4 space-x-reverse ...">
+          <div>01</div>
+          <div>02</div>
+          <div>03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
 </template>

--- a/src/router.js
+++ b/src/router.js
@@ -1,12 +1,22 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import Home from './pages/Home.vue'
 import Flex from './pages/Flex.vue'
+import FlexBasis from './pages/FlexBasis.vue'
+import FlexDirection from './pages/FlexDirection.vue'
+import FlexWrap from './pages/FlexWrap.vue'
+import FlexGrow from './pages/FlexGrow.vue'
+import FlexShrink from './pages/FlexShrink.vue'
 import Spacing from './pages/Spacing.vue'
 
 export const router = createRouter({
   routes: [
     { path: '/', component: Home, name: 'home' },
     { path: '/flex', component: Flex, name: 'flex' },
+    { path: '/flex-basis', component: FlexBasis, name: 'flex-basis' },
+    { path: '/flex-direction', component: FlexDirection, name: 'flex-direction' },
+    { path: '/flex-wrap', component: FlexWrap, name: 'flex-wrap' },
+    { path: '/flex-grow', component: FlexGrow, name: 'flex-grow' },
+    { path: '/flex-shrink', component: FlexShrink, name: 'flex-shrink' },
     { path: '/spacing', component: Spacing, name: 'spacing' },
   ],
   scrollBehavior: () => ({ top: 0 }),


### PR DESCRIPTION
Added doc examples + code examples

Flex-basis
<img width="660" alt="image" src="https://user-images.githubusercontent.com/462825/215485970-2313708a-13fc-437d-a080-a01be5bfdacf.png">

Flex-direction
<img width="657" alt="image" src="https://user-images.githubusercontent.com/462825/215486239-64e1bdf6-2de9-4471-92e0-04669ae6698e.png">

Flex-grow
<img width="659" alt="image" src="https://user-images.githubusercontent.com/462825/215486402-15fa828e-0b11-4c85-beb2-71e686b67a47.png">

Flex-shrink
<img width="661" alt="image" src="https://user-images.githubusercontent.com/462825/215486507-71d3087c-da81-47bd-90d5-6b49a33c98b1.png">

Flex-wrap
<img width="657" alt="image" src="https://user-images.githubusercontent.com/462825/215486107-9661f6ac-5938-466d-9db8-1384b8fa4b1d.png">

Flex 
<img width="663" alt="image" src="https://user-images.githubusercontent.com/462825/215485826-98875a74-8eaa-4c49-bb2b-a6749f4310b4.png">

Spacing - Space-between
<img width="692" alt="image" src="https://user-images.githubusercontent.com/462825/215486877-36cab2fb-372e-4e77-8968-34908ffba317.png">
