### PR TITLE
Add doc examples for order and grid

### DIFF
--- a/src/pages/GridAutoFlow.vue
+++ b/src/pages/GridAutoFlow.vue
@@ -1,0 +1,49 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+<style>
+.grid-flow-row-dense{
+  grid-auto-flow: row dense;
+}
+</style>
+<template>
+  <h1>Order</h1>
+  <container>
+    <box striped class="grid grid-flow-row-dense grid-cols-3 grid-rows-3 gap-4" fg-color="var(--tw-purple-fg)" bg-color="var(--tw-purple-bg)">
+      <div class="bg-purple-800 col-span-2" :class="exampleClasses">01</div>
+      <div class="bg-purple-800 col-span-2" :class="exampleClasses">02</div>
+      <div class="bg-purple-500" :class="exampleClasses">03</div>
+      <div class="bg-purple-800" :class="exampleClasses">04</div>
+      <div class="bg-purple-800" :class="exampleClasses">05</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="grid grid-flow-row-dense grid-cols-3 grid-rows-3 ...">
+          <div class="col-span-2">
+            01
+          </div>
+          <div class="col-span-2">
+            02
+          </div>
+          <div>
+            03
+          </div>
+          <div>
+            04
+          </div>
+          <div>
+            05
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/GridColumnSE.vue
+++ b/src/pages/GridColumnSE.vue
@@ -1,0 +1,67 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Spanning columns</h1>
+  <container>
+    <box class="grid grid-cols-3 gap-4">
+      <div class="bg-indigo-800" :class="exampleClasses">01</div>
+      <div class="bg-indigo-800" :class="exampleClasses">02</div>
+      <div class="bg-indigo-800" :class="exampleClasses">03</div>
+      <div class="bg-indigo-500 col-span-2" :class="exampleClasses">04</div>
+      <div class="bg-indigo-800" :class="exampleClasses">05</div>
+      <div class="bg-indigo-800" :class="exampleClasses">06</div>
+      <div class="bg-indigo-500 col-span-2" :class="exampleClasses">07</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="grid grid-cols-3 ...">
+          <div class="...">01</div>
+          <div class="...">02</div>
+          <div class="...">03</div>
+          <div class="col-span-2 ...">04</div>
+          <div class="...">05</div>
+          <div class="...">06</div>
+          <div class="col-span-2 ...">07</div> 
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+
+  <h1>Starting and ending lines</h1>
+  <container>
+    <div class="grid grid-cols-6 gap-4">
+      <box striped :class="exampleClasses" fg-color="var(--tw-blue-fg)" bg-color="var(--tw-blue-bg)"></box>
+      <div class="bg-blue-500 col-start-2 col-span-4" :class="exampleClasses">01</div>
+      <box striped :class="exampleClasses" fg-color="var(--tw-blue-fg)" bg-color="var(--tw-blue-bg)"></box>
+      <div class="bg-blue-500 col-start-1 col-end-3" :class="exampleClasses">02</div>
+      <box striped :class="exampleClasses" fg-color="var(--tw-blue-fg)" bg-color="var(--tw-blue-bg)"></box>
+      <box striped :class="exampleClasses" fg-color="var(--tw-blue-fg)" bg-color="var(--tw-blue-bg)"></box>
+      <div class="bg-blue-500 col-end-7 col-span-2" :class="exampleClasses">02</div>
+      <div class="bg-blue-500 col-start-1 col-end-7" :class="exampleClasses">02</div>
+    </div>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="grid grid-cols-6 ...">
+          <div class="col-start-2 col-span-4 ...">01</div>
+          <div class="col-start-1 col-end-3 ...">02</div>
+          <div class="col-end-7 col-span-2 ...">03</div>
+          <div class="col-start-1 col-end-7 ...">04</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/GridRowSE.vue
+++ b/src/pages/GridRowSE.vue
@@ -1,0 +1,53 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Spanning rows</h1>
+  <container>
+    <box striped class="grid grid-rows-3 grid-flow-col gap-4" fg-color="var(--tw-fuchsia-fg)" bg-color="var(--tw-fuchsia-bg)">
+      <div class="bg-fuchsia-500 row-span-3" :class="exampleClasses">01</div>
+      <div class="bg-fuchsia-800 col-span-2" :class="exampleClasses">02</div>
+      <div class="bg-fuchsia-500 col-span-2 row-span-2" :class="exampleClasses">03</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="grid grid-rows-3 grid-flow-col ...">
+          <div class="row-span-3 ...">01</div>
+          <div class="col-span-2 ...">02</div>
+          <div class="row-span-2 col-span-2 ...">03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+
+  <h1>Starting and ending lines</h1>
+  <container>
+    <box striped class="grid grid-rows-3 grid-flow-col gap-4">
+      <div class="bg-blue-500 row-start-2 row-span-2 ..." :class="exampleClasses">01</div>
+      <div class="bg-blue-500 row-end-3 row-span-2 ..." :class="exampleClasses">02</div>
+      <div class="bg-blue-500 row-start-1 row-end-4" :class="exampleClasses">03</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="grid grid-rows-3 grid-flow-col ...">
+          <div class="row-start-2 row-span-2 ...">01</div>
+          <div class="row-end-3 row-span-2 ...">02</div>
+          <div class="row-start-1 row-end-4 ...">03</div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/GridTemplateColumns.vue
+++ b/src/pages/GridTemplateColumns.vue
@@ -1,0 +1,37 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Grid template columns</h1>
+  <container class="overflow-auto">
+    <box striped class="grid grid-cols-4 gap-4" fg-color="var(--tw-pink-fg)" bg-color="var(--tw-pink-bg)">
+      <div class="bg-pink-500" :class="exampleClasses">01</div>
+      <div class="bg-pink-500" :class="exampleClasses">02</div>
+      <div class="bg-pink-500" :class="exampleClasses">03</div>
+      <div class="bg-pink-500" :class="exampleClasses">04</div>
+      <div class="bg-pink-500" :class="exampleClasses">05</div>
+      <div class="bg-pink-500" :class="exampleClasses">06</div>
+      <div class="bg-pink-500" :class="exampleClasses">07</div>
+      <div class="bg-pink-500" :class="exampleClasses">08</div>
+      <div class="bg-pink-500" :class="exampleClasses">09</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      
+        <div class="grid grid-cols-4 ...">
+          <div>01</div>
+          <!-- ... -->
+          <div>09</div>
+        </div>
+    
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/GridTemplateRows.vue
+++ b/src/pages/GridTemplateRows.vue
@@ -1,0 +1,37 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Grid template rows</h1>
+  <container class="overflow-auto">
+    <box striped class="grid grid-rows-4 grid-flow-col gap-4" fg-color="var(--tw-pink-fg)" bg-color="var(--tw-pink-bg)">
+      <div class="bg-pink-500" :class="exampleClasses">01</div>
+      <div class="bg-pink-500" :class="exampleClasses">02</div>
+      <div class="bg-pink-500" :class="exampleClasses">03</div>
+      <div class="bg-pink-500" :class="exampleClasses">04</div>
+      <div class="bg-pink-500" :class="exampleClasses">05</div>
+      <div class="bg-pink-500" :class="exampleClasses">06</div>
+      <div class="bg-pink-500" :class="exampleClasses">07</div>
+      <div class="bg-pink-500" :class="exampleClasses">08</div>
+      <div class="bg-pink-500" :class="exampleClasses">09</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      
+        <div class="grid grid-rows-4 grid-flow-col ...">
+          <div>01</div>
+          <!-- ... -->
+          <div>09</div>
+        </div>
+    
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/pages/Order.vue
+++ b/src/pages/Order.vue
@@ -1,0 +1,37 @@
+<script setup>
+// Note there's a way we can just import these globally so we don't have to do it in every page
+import Box from '../components/Box.vue'
+import Container from '../components/Container.vue'
+
+const exampleClasses = 'p-4 rounded-2 text-white flex items-center justify-center'
+</script>
+
+<template>
+  <h1>Order</h1>
+  <container>
+    <box class="flex justify-between gap-4">
+      <div class="bg-indigo-500 order-last" :class="exampleClasses">01</div>
+      <div class="bg-indigo-500" :class="exampleClasses">02</div>
+      <div class="bg-indigo-500" :class="exampleClasses">03</div>
+    </box>
+  </container>
+  <h2>Code example</h2>
+  <container>
+    <syntax-highlighter>
+      <!--
+        <div class="flex justify-between">
+          <div class="order-last">
+            01
+          </div>
+          <div>
+            02
+          </div>
+          <div>
+            03
+          </div>
+        </div>
+      -->
+    </syntax-highlighter>    
+  </container>
+
+</template>

--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,12 @@ import FlexDirection from './pages/FlexDirection.vue'
 import FlexWrap from './pages/FlexWrap.vue'
 import FlexGrow from './pages/FlexGrow.vue'
 import FlexShrink from './pages/FlexShrink.vue'
+import Order from './pages/Order.vue'
+import GridTemplateColumns from './pages/GridTemplateColumns.vue'
+import GridColumnSE from './pages/GridColumnSE.vue'
+import GridTemplateRows from './pages/GridTemplateRows.vue'
+import GridRowSE from './pages/GridRowSE.vue'
+import GridAutoFlow from './pages/GridAutoFlow.vue'
 import Spacing from './pages/Spacing.vue'
 
 export const router = createRouter({
@@ -17,6 +23,12 @@ export const router = createRouter({
     { path: '/flex-wrap', component: FlexWrap, name: 'flex-wrap' },
     { path: '/flex-grow', component: FlexGrow, name: 'flex-grow' },
     { path: '/flex-shrink', component: FlexShrink, name: 'flex-shrink' },
+    { path: '/order', component: Order, name: 'order' },
+    { path: '/grid-template-columns', component: GridTemplateColumns, name: 'grid-template-columns' },
+    { path: '/grid-column-se', component: GridColumnSE, name: 'grid-column-se' },
+    { path: '/grid-template-rows', component: GridTemplateRows, name: 'grid-template-rows' },
+    { path: '/grid-row-se', component: GridRowSE, name: 'grid-row-se' },
+    { path: '/grid-auto-flow', component: GridAutoFlow, name: 'grid-auto-flow' },
     { path: '/spacing', component: Spacing, name: 'spacing' },
   ],
   scrollBehavior: () => ({ top: 0 }),


### PR DESCRIPTION
Order
<img width="773" alt="image" src="https://user-images.githubusercontent.com/462825/215767430-e96b5d82-8d42-4e17-8108-ca76c030373d.png">

Grid-template-columns
<img width="773" alt="image" src="https://user-images.githubusercontent.com/462825/215767719-4e9159d3-c65b-4570-a1de-47894dc61ceb.png">

Grid-column-start/end
<img width="772" alt="image" src="https://user-images.githubusercontent.com/462825/215767881-1200bdfb-d1bb-44fa-8c72-802eb5a7e419.png">

Grid-template-rows
<img width="771" alt="image" src="https://user-images.githubusercontent.com/462825/215768022-71d363db-74c2-4500-92f0-de6ef51101c8.png">

Grid-row-start/end
<img width="772" alt="image" src="https://user-images.githubusercontent.com/462825/215768156-f7ea7b4f-ebc6-49dd-9594-41e09070ca0c.png">

Grid-auto-flow
<img width="774" alt="image" src="https://user-images.githubusercontent.com/462825/215767312-4e0ca623-6a72-47ca-8b88-59b49c1ae314.png">